### PR TITLE
Add openssl3 legacy support for PKCS12 repackaging

### DIFF
--- a/tcsg4-install-credential.sh
+++ b/tcsg4-install-credential.sh
@@ -293,7 +293,7 @@ fi
 openssl pkcs12 -export \
     -passin env:NPW -inkey "$tempdir/key-$credbase.pem" \
     -certfile "$destdir/chain-$credbase.pem" \
-    -name "$friendlyname" -in "$pkcs12eec" \
+    -name "$friendlyname" -in "$pkcs12eec" $OSSL3_LEGACY \
     -passout env:NPW -out "$destdir/package-$credbase.p12"
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
OpenSSL 3.x has changed its default algorithm in pkcs12, which is not compatible with embedded security framework in macOS. By adding the -legacy flag, it will load the legacy provider which uses RC2_CBC or 3DES_CBC as the default algorithm for certificate encryption.